### PR TITLE
Missing link

### DIFF
--- a/checklist.html.md.erb
+++ b/checklist.html.md.erb
@@ -167,7 +167,7 @@ In some cases, if you have previously disabled lifecycle errands for any install
 
 #### <a id="cipher"></a> Confirm Cipher Suites
 
-Ensure that the **TLS Cipher Suites for Router** field contains a cipher suite supported by both Gorouter and CAPI. For details, see [Removal of Default Ciphers Causes Downtime when Upgrading from 2.2 to 2.3 and from 2.3 to 2.4](https://docs.pivotal.io/pivotalcf/2-4/pcf-release-notes/runtime-rn#cipher-downtime).
+Ensure that the **TLS Cipher Suites for Router** field contains a cipher suite supported by both Gorouter and CAPI. For details, see [Removal of Default Ciphers Causes Downtime when Upgrading from 2.2 to 2.3 and from 2.3 to 2.4](https://docs.pivotal.io/pivotalcf/2-4/pcf-release-notes/runtime-rn.html#cipher-downtime).
 
 #### <a id="groot-gc"></a> Configure Diego Cell Garbage collection
 


### PR DESCRIPTION
Missing link for "Removal of Default Ciphers Causes Downtime when Upgrading from 2.2 to 2.3 and from 2.3 to 2.4"