### PR TITLE
Missing link for "HTTP Healthcheck Server Disabled for SSH Proxy"

### DIFF
--- a/checklist.html.md.erb
+++ b/checklist.html.md.erb
@@ -232,7 +232,7 @@ With each release of a new <%= vars.product_name %> version, PAS may require spe
 
 If your SSH load balancer is configured with an HTTP healthcheck, remove the healthcheck before upgrading. This is the load balancer specified in the **Diego Brain** row of the **Resource Config** pane. 
 
-For more information, see [HTTP Healthcheck Server Disabled for SSH Proxy](https://docs.pivotal.io/pivotalcf/2-6/pcf-release-notes/breaking-changes#http-healtcheck). 
+For more information, see [HTTP Healthcheck Server Disabled for SSH Proxy](https://docs.pivotal.io/pivotalcf/2-6/pcf-release-notes/breaking-changes.html#http-healtcheck). 
 
 #### <a id="disable-unused-errands"></a> (Optional) Disable Unused Errands
 


### PR DESCRIPTION
The URL link for the page "HTTP Healthcheck Server Disabled for SSH Proxy" is incorrect. I fixed as below.

Incorrect URL) https://docs.pivotal.io/pivotalcf/2-6/pcf-release-notes/breaking-changes#http-healtcheck
Correct URL) https://docs.pivotal.io/pivotalcf/2-6/pcf-release-notes/breaking-changes.html#http-healtcheck