### PR TITLE
Add note for checking internal MySQL RAM

### DIFF
--- a/checklist.html.md.erb
+++ b/checklist.html.md.erb
@@ -388,6 +388,14 @@ In addition to file storage IOPS, consider additional existing deployment factor
 
 To see example upgrade-related performance measurements of an existing production <%= vars.product_name %> deployment, see [Upgrade Load Example: Pivotal Web Services](../opsguide/pws_upgrade_load.html).
 
+### <a id="check-mysql-ram"></a> Check Internal MySQL RAM
+
+The MySQL Buffer Pool size has changed from 2&nbsp;GB to 50% of available memory.
+
+You may need to choose a VM type with a larger amount of RAM to avoid Out of Memory (OOM) errors.
+
+For example, if the internal MySQL VM is configured with 8&nbsp;GB of RAM and 6&nbsp;GB is currently being used, then 2&nbsp;GB is consumed by the buffer pool while 4&nbsp;GB is consumed by everything else. Upgrading <%= vars.app_runtime_abbr %> will cause OOM errors since the buffer pool will now consume 4&nbsp;GB, leaving 0&nbsp;GB of available RAM.
+
 ### <a id="bosh-clean-up"></a> Run BOSH Clean-Up
 
 Run `bosh -e ALIAS clean-up --all` to clean up old stemcells, releases, orphaned disks, and other resources before upgrade. This cleanup helps prevent the product and stemcell upload process from exceeding the BOSH Director's available persistent disk space.


### PR DESCRIPTION
I incorrectly mentioned in https://github.com/pivotal-cf/docs-pcf-upgrade/pull/18 that this was a 2.5->2.6 upgrade.

It's also relevant for the 2.4 -> 2.5 upgrade since this change is present in 2.5.13